### PR TITLE
Calculate actual probabilities to win a fight

### DIFF
--- a/hh-plus-plus.js
+++ b/hh-plus-plus.js
@@ -4318,6 +4318,7 @@ function moduleSim() {
 
 //Battle simulation
 function simuFight(player, opponent) {
+    const logging = false;
     let playerEgoCheck = 0;
     let opponentEgoCheck = 0;
 
@@ -4349,19 +4350,21 @@ function simuFight(player, opponent) {
     player.ego -= Math.max(0, opponent.atk - player.def);
 
     //Log opponent name and starting egos for sim
-    console.log('Simulation log for: ' + opponent.name);
-    console.log('Starting Egos adjusted for the case proc scenario (0 for you and 1 for the opponent):');
-    console.log('Player Ego: ' + player.ego);
-    console.log('Opponent Ego: ' + opponent.ego);
+    if (logging) {
+        console.log('Simulation log for: ' + opponent.name);
+        console.log('Starting Egos adjusted for the case proc scenario (0 for you and 1 for the opponent):');
+        console.log('Player Ego: ' + player.ego);
+        console.log('Opponent Ego: ' + opponent.ego);
+    }
 
     function play_turn(cur) {
         let o = cur === player ? opponent : player;
 
         o.ego -= Math.max(0, cur.atk - o.def);
-        console.log('Round ' + (turns + 1) + ': ' + cur.text + ' hit! -' + Math.max(0, (cur.atk - o.def)));
+        if(logging) console.log('Round ' + (turns + 1) + ': ' + cur.text + ' hit! -' + Math.max(0, (cur.atk - o.def)));
 
         //Log results
-        console.log('after Round ' + (turns + 1) + ': ' + o.text + ' ego: ' + o.ego);
+        if(logging) console.log('after Round ' + (turns + 1) + ': ' + o.text + ' ego: ' + o.ego);
     }
 
     //Simulate challenge
@@ -4372,7 +4375,7 @@ function simuFight(player, opponent) {
             opponentEgoCheck = opponent.ego;
             opponentEgoCheck -= player.atk - opponent.def;
 
-            if (opponentEgoCheck <= 0)
+            if (logging && opponentEgoCheck <= 0)
                 console.log('Victory! With 1 critical hit for player, Opponent ego: ' + opponentEgoCheck);
 
             player.ego = 0;
@@ -4385,7 +4388,7 @@ function simuFight(player, opponent) {
             playerEgoCheck = player.ego;
             playerEgoCheck -= opponent.atk - player.def;
 
-            if (playerEgoCheck <= 0)
+            if (logging && playerEgoCheck <= 0)
                 console.log('Defeat! With 1 more critical hit for opponent, Player ego: ' + playerEgoCheck);
 
             opponent.ego = 0;
@@ -4428,6 +4431,7 @@ function simuFight(player, opponent) {
 
 // Calculate the chance to win the fight
 function calcWinProbability(player, opponent) {
+    const logging = true;
     // check edge cases and shortcuts
     if (player.dmg <= 0) {
         return {
@@ -4486,33 +4490,33 @@ function calcWinProbability(player, opponent) {
     let playerCrits = 0;
     let playerNormalHits = Math.ceil(opponent.hp/player.dmg);
 
-    console.log('Probability calculation log for: ' + opponent.name);
+    if(logging) console.log('Probability calculation log for: ' + opponent.name);
     do {
-        console.log(' Scenario: ' + playerCrits + ' crits and ' + playerNormalHits + ' hits');
+        if(logging) console.log(' Scenario: ' + playerCrits + ' crits and ' + playerNormalHits + ' hits');
         let scenarioLikelihood = calculateChance(playerCrits, playerNormalHits, player.critchance);
         let overkillChance = calculateOverkillChance(playerCrits, playerNormalHits, player.critchance);
-        console.log('  Scenario likelihood: ' + 100*scenarioLikelihood + ' % + ' + 100*overkillChance + ' % chance for overkill');
+        if(logging) console.log('  Scenario likelihood: ' + 100*scenarioLikelihood + ' % + ' + 100*overkillChance + ' % chance for overkill');
         scenarioLikelihood += overkillChance;
 
         let rounds = playerCrits + playerNormalHits;
         let tolerableCrits = tolerableHits-rounds+1;
-        console.log('  Opponent is allowed to crit ' + tolerableCrits + ' times');
+        if(logging) console.log('  Opponent is allowed to crit ' + tolerableCrits + ' times');
 
         if (tolerableCrits < 0) {
-            console.log('  => impossible, we lose');
+            if(logging) console.log('  => impossible, we lose');
             loseChance += scenarioLikelihood;
         } else if (tolerableCrits >= rounds-1) {
-            console.log ('  => guaranteed, we win');
+            if(logging) console.log ('  => guaranteed, we win');
             winChance += scenarioLikelihood;
         } else {
             let opponentLikelihood = 0;
             for(let i=0; i<=tolerableCrits; i++) {
                 let tmp = calculateChance(i, rounds-i-1, opponent.critchance);
-                console.log('   probability for ' + i + ' crits and ' + (rounds-i-1) + ' hits: ' + 100*tmp + ' %');
+                if(logging) console.log('   probability for ' + i + ' crits and ' + (rounds-i-1) + ' hits: ' + 100*tmp + ' %');
                 opponentLikelihood += tmp;
             }
-            console.log('  ' + 100*opponentLikelihood + ' % chance that this condition is fulfilled');
-            console.log('  => ' + 100*opponentLikelihood*scenarioLikelihood + ' % to win through this scenario');
+            if(logging) console.log('  ' + 100*opponentLikelihood + ' % chance that this condition is fulfilled');
+            if(logging) console.log('  => ' + 100*opponentLikelihood*scenarioLikelihood + ' % to win through this scenario');
             winChance += opponentLikelihood*scenarioLikelihood;
             loseChance += (1-opponentLikelihood)*scenarioLikelihood;
         }
@@ -4521,7 +4525,7 @@ function calcWinProbability(player, opponent) {
         playerNormalHits-=2;
     } while (playerNormalHits >= 0);
 
-    console.log(100*winChance+ ' % chance to win vs. ' + 100*loseChance + ' % chance to lose => ' + 100*(winChance+loseChance) + ' % total coverage.');
+    if(logging) console.log(100*winChance+ ' % chance to win vs. ' + 100*loseChance + ' % chance to lose => ' + 100*(winChance+loseChance) + ' % total coverage.');
 
     return {
         scoreStr: (100*winChance).toFixed(2) + '%',

--- a/hh-plus-plus.js
+++ b/hh-plus-plus.js
@@ -368,6 +368,7 @@ texts.en = {
     optionsLeague: 'League information',
     optionsLeagueBoard: 'Show the league tops',
     optionsSimFight : 'League / Season / Villains sim',
+    optionsLogSimFight : 'Detailed logging in the browser console',
     optionsTeamsFilter: 'Teams filter',
     optionsChampions: 'Champions information',
     optionsLinks: 'Shortcuts/Timers',
@@ -523,6 +524,7 @@ texts.fr = {
     optionsLeague: 'Infos ligue',
     optionsLeagueBoard: 'Montrer les tops ligue',
     optionsSimFight: 'Simu ligue / saison / combats de troll',
+    optionsLogSimFight : 'Journalisation détaillée dans la console du navigateur',
     optionsTeamsFilter: 'Filtre d\'équipes',
     optionsChampions: 'Infos champions',
     optionsLinks: 'Raccourcis/Timers',
@@ -678,6 +680,7 @@ texts.es = {
     optionsLeague: 'Informacion de Liga',
     optionsLeagueBoard: 'Mostrar los mejores de la liga',
     optionsSimFight: 'Simulacion de Liga / Temporada / Villano',
+    optionsLogSimFight: 'Registro detallado en la consola del navegador',
     optionsTeamsFilter: 'Filtro de equipos',
     optionsChampions: 'Informacion de Campeones',
     optionsLinks: 'Atajos/Temporizadores',
@@ -832,6 +835,7 @@ texts.it = {
     optionsLeague: 'Informazioni sulle Leghe',
     optionsLeagueBoard: 'Mostra i top della lega',
     optionsSimFight: 'Simulazione Leghe / Stagione / Troll',
+    optionsLogSimFight : 'Accesso dettagliato nella console del browser',
     optionsTeamsFilter: 'Filtro delle squadre',
     optionsChampions: 'Informazioni sui Campioni',
     optionsLinks: 'Scorciatoie/Timer',
@@ -986,6 +990,7 @@ texts.de = {
     optionsLeague: 'Liga-Informationen',
     optionsLeagueBoard: 'Die Liga-Spitzen anzeigen',
     optionsSimFight: 'Liga/Saison/Widersacher-Simulation',
+    optionsLogSimFight: 'Detaillierte Protokollierung in der Browserkonsole',
     optionsTeamsFilter: 'Mannschaften filtern',
     optionsChampions: 'Champion-Informationen',
     optionsLinks: 'Abkürzungen/Zeitgeber',
@@ -1243,6 +1248,7 @@ function loadSetting(e){
 			||e=='league'
 			||e=='leagueBoard'
 			||e=='simFight'
+			//||e=='logSimFight'
 			||e=='teamsFilter'
 			||e=='champions'
 			||e=='links'
@@ -1364,6 +1370,7 @@ function options() {
                                  + '<label class="switch"><input type="checkbox" hhs="league"><span class="slider"></span></label>' + texts[lang].optionsLeague + '<br />'
                                  + '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<label class="switch"><input type="checkbox" hhs="leagueBoard"><span class="slider"></span></label>' + texts[lang].optionsLeagueBoard + '<br />'
                                  + '<label class="switch"><input type="checkbox" hhs="simFight"><span class="slider"></span></label>' + texts[lang].optionsSimFight + '<br />'
+                                 + '&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<label class="switch"><input type="checkbox" hhs="logSimFight"><span class="slider"></span></label>' + texts[lang].optionsLogSimFight + '<br />'
                                  + '<label class="switch"><input type="checkbox" hhs="teamsFilter"><span class="slider"></span></label>' + texts[lang].optionsTeamsFilter + '<br />'
                                  + '<label class="switch"><input type="checkbox" hhs="champions"><span class="slider"></span></label>' + texts[lang].optionsChampions + '<br />'
                                  + '<label class="switch"><input type="checkbox" hhs="links"><span class="slider"></span></label>' + texts[lang].optionsLinks + '<br />'
@@ -1417,6 +1424,20 @@ function options() {
         if ($(this).is(':checked')) {
             $('[hhs=league]').prop('checked', true);
             localStorage.setItem('HHS.league', true)
+        }
+    });
+
+    // Dependency of fight simulation options
+    $('[hhs=simFight]').click(function() {
+        if (!$(this).is(':checked')) {
+            $('[hhs=logSimFight]').prop('checked', false);
+            localStorage.setItem('HHS.logSimFight', false)
+        }
+    });
+    $('[hhs=logSimFight]').click(function() {
+        if ($(this).is(':checked')) {
+            $('[hhs=simFight]').prop('checked', true);
+            localStorage.setItem('HHS.simFight', true)
         }
     });
 
@@ -4344,7 +4365,7 @@ function moduleSim() {
 
 //Battle simulation
 function simuFight(player, opponent) {
-    const logging = false;
+    const logging = loadSetting("logSimFight");
     let playerEgoCheck = 0;
     let opponentEgoCheck = 0;
 
@@ -4479,7 +4500,7 @@ function calculateOverkillChance(crits, hits, critchance) {
 
 // Calculate the chance to win the fight
 function calcWinProbability(player, opponent) {
-    const logging = true;
+    const logging = loadSetting("logSimFight");
     // check edge cases and shortcuts
     if (player.dmg <= 0) {
         return {
@@ -4551,13 +4572,13 @@ function calcWinProbability(player, opponent) {
     if(logging) console.log(100*winChance+ ' % chance to win vs. ' + 100*loseChance + ' % chance to lose => ' + 100*(winChance+loseChance) + ' % total coverage.');
 
     return {
-        scoreStr: (100*winChance).toFixed(2) + '%',
+        scoreStr: nRounding(100*winChance, 2, -1) + '%',
         scoreClass: winChance>0.9?"plus":winChance<0.5?"minus":"close"
     };
 }
 
 function calcLeagueProbabilities(player, opponent) {
-    const logging=true;
+    const logging = loadSetting("logSimFight");
     let ret = new Array(26); // Array with probabilities, key = points
 
     if (player.dmg <= 0) {
@@ -4637,7 +4658,7 @@ function calcLeagueProbabilities(player, opponent) {
         playerCrits--;
         playerHits+=2;
     } while (playerCrits >= 0);
-    if(logging) console.log('Total % covered (should be 100): ' + 100*ret.reduce((a,b)=>a+b,0);
+    if(logging) console.log('Total % covered (should be 100): ' + 100*ret.reduce((a,b)=>a+b,0));
     return ret;
 }
 /* =========================================


### PR DESCRIPTION
I always thought I'd be more interested in the chance to win a season fight instead of some estimated leftover ego which ignores harmony for the calculations. Especially with the new simplified fighting system this became feasible and so I did just that. Hopefully the upcoming active skills can be incorporated.

My focus was more on the calculations and I've kept changes to the front-end to a minimum. For now I've left all simulation results untouched for easy comparison and sanity checking. 
In season I display the chance to win in the top-right corner (long opponent names may push it away). For league I've added detailed probabilities for all possible points as a tooltip to the simulation result. 

Just like in the old simulation there is extensive logging for debugging which can be disabled (and imo should be in the release).

I'm curious for some feedback on my proposal.