### PR TITLE
Make win probability in leagues immediately visible

### DIFF
--- a/src/modules/BattleSimulatorModule/League.js
+++ b/src/modules/BattleSimulatorModule/League.js
@@ -123,7 +123,7 @@ class League {
 
         $('.matchRating').remove()
 
-        const $rating = $(`<div class="matchRating" style="color:${pointGrade[Math.round(expectedValue)]};" generic-tooltip="${probabilityTooltip}">E[X]:<br/>${I18n.nRounding(expectedValue, this.highPrecisionMode ? 2: 1, 0)}</div>`)
+        const $rating = $(`<div class="matchRating" style="color:${pointGrade[Math.round(expectedValue)]};" generic-tooltip="${probabilityTooltip}">E[X]:<br/>${I18n.nRounding(expectedValue, this.highPrecisionMode ? 2: 1, 0)}<br/>${(100*win).toFixed(0)}%</div>`)
         $('#leagues_right .average-lvl').wrap('<div class="gridWrapper"></div>').after($rating)
         $('.lead_table_default > td:nth-child(1) > div:nth-child(1) > div:nth-child(2) .level').append($rating)
     }


### PR DESCRIPTION
I like to see the win probability without hovering the mouse over the "E[X]", so I added it. This solves the easy part of #55