### PR TITLE
Fixing broken timer in Club Champion

### DIFF
--- a/src/modules/ResourceBarsModule/index.js
+++ b/src/modules/ResourceBarsModule/index.js
@@ -304,7 +304,7 @@ class ResourceBarsModule extends CoreModule {
 
         const $barHTML = $(`
             <a class="script-pop-timer" href="/activities.html?tab=pop">
-                <div class="hh_bar finish_in_bar" ${inProgress ? `generic-tooltip="${this.label('readyAt', {time: formattedDate})}"` : ''}>
+                <div class="hh_bar" ${inProgress ? `generic-tooltip="${this.label('readyAt', {time: formattedDate})}"` : ''}>
                     <div class="backbar borderbar">
                         <div class="frontbar ${inProgress ? 'pinkbar' : 'bluebar'}" style="width: ${barWidth}%"></div>
                     </div>


### PR DESCRIPTION
Club Champion timer is broken because PoP timer conflicts with the Club Champion timer.
![before](https://user-images.githubusercontent.com/101486573/184522334-a14943da-ae1e-4e43-aa98-23c1c01db53f.png)
![after](https://user-images.githubusercontent.com/101486573/184522335-585cfcb5-2af5-43ca-bd82-4af417984ef8.png)

Conflict occurs in clubs.html
![code](https://user-images.githubusercontent.com/101486573/184522336-376e8592-0cf7-49d7-baee-2273d37dcf44.png)
.